### PR TITLE
Fixes: Undefined offset 1 in Lumen

### DIFF
--- a/src/Prettus/Validator/AbstractValidator.php
+++ b/src/Prettus/Validator/AbstractValidator.php
@@ -168,7 +168,7 @@ abstract class AbstractValidator implements ValidatorInterface {
             foreach($rules as $ruleIdx => $rule)
             {
                 // get name and parameters
-                @list($name, $params) = explode(":", $rule);
+                @list($name, $params) = array_pad(explode(":", $rule), 2, null);
 
                 // only do someting for the unique rule
                 if(strtolower($name) != "unique") {


### PR DESCRIPTION
In Lumen, when trying to update a model I got:

```
ErrorException in AbstractValidator.php line 171:
Undefined offset: 1
```

I tried to see if updating worked in Laravel 5, it did, without any problems.
I then researched some more on the undefined issue.
This is what led me to the solution: https://www.daniweb.com/web-development/php/threads/452877/-how-to-prevent-undefined-offset-1-

I can confirm that my fix works in both Laravel 5 and Lumen.
I hope you accept this pull request.

Thanks.
